### PR TITLE
Use TBD proxy/caching repo for all 3rdparty deps

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,9 +10,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://jitpack.io")
-        maven("https://repo.danubetech.com/repository/maven-public/")
-
+        // Thirdparty dependencies of TBD projects not in Maven Central
+        maven("https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/")
     }
 }
 


### PR DESCRIPTION
Wanna give this a whirl, @michaelneale?

The TBD `thirdparty` repo is what Artifactory calls a "Virtual" repository; it delegates to several "remote" repositories, for instance `danubetech`, `jitpack`, and `jboss-thirdparty`. Then it caches results. So we can uniformly depend on one 3rdparty repo and even if the underlying repos disappear, we're cached.

It's located: https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/

Trying out here and some other lower-risk places for a bit before solidifying the configs and rolling out to the upstream teams.

Acts as acceptance test for:
* https://github.com/TBD54566975/open-source-programs/issues/116